### PR TITLE
reuseport plugin

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	// The port to listen on.
 	Port string
 
+	// The number of servers that will listen on one port.
+	// By default, one server will be running.
+	NumSocks int
+
 	// Root points to a base directory we find user defined "things".
 	// First consumer is the file plugin to looks for zone files in this place.
 	Root string

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -115,7 +115,6 @@ func (h *dnsContext) InspectServerBlocks(sourceFile string, serverBlocks []caddy
 				ListenHosts: []string{""},
 				Port:        za.Port,
 				Transport:   za.Transport,
-				NumSocks:    1,
 			}
 
 			// Set reference to the first config in the current block.
@@ -135,72 +134,23 @@ func (h *dnsContext) InspectServerBlocks(sourceFile string, serverBlocks []caddy
 
 // MakeServers uses the newly-created siteConfigs to create and return a list of server instances.
 func (h *dnsContext) MakeServers() ([]caddy.Server, error) {
-	// Copy the Plugin, ListenHosts and Debug from first config in the block
-	// to all other config in the same block . Doing this results in zones
-	// sharing the same plugin instances and settings as other zones in
-	// the same block.
-	for _, c := range h.configs {
-		c.Plugin = c.firstConfigInBlock.Plugin
-		c.ListenHosts = c.firstConfigInBlock.ListenHosts
-		c.Debug = c.firstConfigInBlock.Debug
-		c.Stacktrace = c.firstConfigInBlock.Stacktrace
-		c.NumSocks = c.firstConfigInBlock.NumSocks
-
-		// Fork TLSConfig for each encrypted connection
-		c.TLSConfig = c.firstConfigInBlock.TLSConfig.Clone()
-		c.ReadTimeout = c.firstConfigInBlock.ReadTimeout
-		c.WriteTimeout = c.firstConfigInBlock.WriteTimeout
-		c.IdleTimeout = c.firstConfigInBlock.IdleTimeout
-		c.TsigSecret = c.firstConfigInBlock.TsigSecret
-	}
+	// Copy parameters from first config in the block to all other config in the same block
+	propagateConfigParams(h.configs)
 
 	// we must map (group) each config to a bind address
 	groups, err := groupConfigsByListenAddr(h.configs)
 	if err != nil {
 		return nil, err
 	}
+
 	// then we create a server for each group
 	var servers []caddy.Server
 	for addr, group := range groups {
-		for range group[0].NumSocks {
-			// switch on addr
-			switch tr, _ := parse.Transport(addr); tr {
-			case transport.DNS:
-				s, err := NewServer(addr, group)
-				if err != nil {
-					return nil, err
-				}
-				servers = append(servers, s)
-
-			case transport.TLS:
-				s, err := NewServerTLS(addr, group)
-				if err != nil {
-					return nil, err
-				}
-				servers = append(servers, s)
-
-			case transport.QUIC:
-				s, err := NewServerQUIC(addr, group)
-				if err != nil {
-					return nil, err
-				}
-				servers = append(servers, s)
-
-			case transport.GRPC:
-				s, err := NewServergRPC(addr, group)
-				if err != nil {
-					return nil, err
-				}
-				servers = append(servers, s)
-
-			case transport.HTTPS:
-				s, err := NewServerHTTPS(addr, group)
-				if err != nil {
-					return nil, err
-				}
-				servers = append(servers, s)
-			}
+		serversForGroup, err := makeServersForGroup(addr, group)
+		if err != nil {
+			return nil, err
 		}
+		servers = append(servers, serversForGroup...)
 	}
 
 	// For each server config, check for View Filter plugins
@@ -300,6 +250,27 @@ func (h *dnsContext) validateZonesAndListeningAddresses() error {
 	return nil
 }
 
+// propagateConfigParams copies the necessary parameters from first config in the block
+// to all other config in the same block. Doing this results in zones
+// sharing the same plugin instances and settings as other zones in
+// the same block.
+func propagateConfigParams(configs []*Config) {
+	for _, c := range configs {
+		c.Plugin = c.firstConfigInBlock.Plugin
+		c.ListenHosts = c.firstConfigInBlock.ListenHosts
+		c.Debug = c.firstConfigInBlock.Debug
+		c.Stacktrace = c.firstConfigInBlock.Stacktrace
+		c.NumSocks = c.firstConfigInBlock.NumSocks
+
+		// Fork TLSConfig for each encrypted connection
+		c.TLSConfig = c.firstConfigInBlock.TLSConfig.Clone()
+		c.ReadTimeout = c.firstConfigInBlock.ReadTimeout
+		c.WriteTimeout = c.firstConfigInBlock.WriteTimeout
+		c.IdleTimeout = c.firstConfigInBlock.IdleTimeout
+		c.TsigSecret = c.firstConfigInBlock.TsigSecret
+	}
+}
+
 // groupConfigsByListenAddr groups site configs by their listen
 // (bind) address, so sites that use the same listener can be served
 // on the same server instance. The return value maps the listen
@@ -319,6 +290,63 @@ func groupConfigsByListenAddr(configs []*Config) (map[string][]*Config, error) {
 	}
 
 	return groups, nil
+}
+
+// makeServersForGroup creates servers for a specific transport and group.
+// It creates as many servers as specified in the NumSocks configuration.
+// If the NumSocks param is not specified, one server is created by default.
+func makeServersForGroup(addr string, group []*Config) ([]caddy.Server, error) {
+	// that is impossible, but better to check
+	if len(group) == 0 {
+		return nil, fmt.Errorf("no configs for group defined")
+	}
+	// create one server by default if no NumSocks specified
+	numSocks := 1
+	if group[0].NumSocks > 0 {
+		numSocks = group[0].NumSocks
+	}
+
+	var servers []caddy.Server
+	for range numSocks {
+		// switch on addr
+		switch tr, _ := parse.Transport(addr); tr {
+		case transport.DNS:
+			s, err := NewServer(addr, group)
+			if err != nil {
+				return nil, err
+			}
+			servers = append(servers, s)
+
+		case transport.TLS:
+			s, err := NewServerTLS(addr, group)
+			if err != nil {
+				return nil, err
+			}
+			servers = append(servers, s)
+
+		case transport.QUIC:
+			s, err := NewServerQUIC(addr, group)
+			if err != nil {
+				return nil, err
+			}
+			servers = append(servers, s)
+
+		case transport.GRPC:
+			s, err := NewServergRPC(addr, group)
+			if err != nil {
+				return nil, err
+			}
+			servers = append(servers, s)
+
+		case transport.HTTPS:
+			s, err := NewServerHTTPS(addr, group)
+			if err != nil {
+				return nil, err
+			}
+			servers = append(servers, s)
+		}
+	}
+	return servers, nil
 }
 
 // DefaultPort is the default port.

--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -16,6 +16,7 @@ var Directives = []string{
 	"cancel",
 	"tls",
 	"timeouts",
+	"reuseport",
 	"reload",
 	"nsid",
 	"bufsize",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/pprof"
 	_ "github.com/coredns/coredns/plugin/ready"
 	_ "github.com/coredns/coredns/plugin/reload"
+	_ "github.com/coredns/coredns/plugin/reuseport"
 	_ "github.com/coredns/coredns/plugin/rewrite"
 	_ "github.com/coredns/coredns/plugin/root"
 	_ "github.com/coredns/coredns/plugin/route53"

--- a/plugin/reuseport/README.md
+++ b/plugin/reuseport/README.md
@@ -1,0 +1,30 @@
+# reuseport
+
+## Name
+
+*reuseport* - allows to define the number of servers that will listen on one port.
+
+## Description
+
+With *reuseport*, you can define the number of servers that will listen on one port. The SO_REUSEPORT socket option allows 
+multiple UDP sockets to be bound to the same port. Because of this, it is possible to run multiple servers on one port.
+This allows to increase the throughput of CoreDNS on a server with a large number of cores.
+
+## Syntax
+
+~~~
+reuseport [NUM_SOCKS]
+~~~
+
+* **NUM_SOCKS** - the number of servers that will listen on one port.
+
+## Examples
+
+Start 5 TCP/UDP servers on port 53.
+
+~~~ corefile
+.:53 {
+	reuseport 5
+	forward . /etc/resolv.conf
+}
+~~~

--- a/plugin/reuseport/README.md
+++ b/plugin/reuseport/README.md
@@ -6,9 +6,12 @@
 
 ## Description
 
-With *reuseport*, you can define the number of servers that will listen on one port. The SO_REUSEPORT socket option allows 
-multiple UDP sockets to be bound to the same port. Because of this, it is possible to run multiple servers on one port.
-This allows to increase the throughput of CoreDNS on a server with a large number of cores.
+With *reuseport*, you can define the number of servers that will listen on the same port. The SO_REUSEPORT socket option
+allows to open multiple listening sockets at the same address and port. In this case, kernel distributes incoming 
+connections between sockets.
+
+Enabling this option allows to start multiple servers, which increases the throughput of CoreDNS in environments with a 
+large number of CPU cores.
 
 ## Syntax
 
@@ -28,3 +31,10 @@ Start 5 TCP/UDP servers on port 53.
 	forward . /etc/resolv.conf
 }
 ~~~
+
+## Limitations
+
+The SO_REUSEPORT socket option is not available for some operating systems. It is available since Linux Kernel 3.9 and 
+not available for Windows at all.
+
+Using this plugin with a system that does not support SO_REUSEPORT will cause an `address already in use` error.

--- a/plugin/reuseport/reuseport.go
+++ b/plugin/reuseport/reuseport.go
@@ -1,0 +1,40 @@
+package reuseport
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+)
+
+func init() { plugin.Register("reuseport", setup) }
+
+func setup(c *caddy.Controller) error {
+	err := parseNumSocks(c)
+	if err != nil {
+		return plugin.Error("reuseport", err)
+	}
+	return nil
+}
+
+func parseNumSocks(c *caddy.Controller) error {
+	config := dnsserver.GetConfig(c)
+
+	for c.Next() {
+		args := c.RemainingArgs()
+		if len(args) != 1 {
+			return c.ArgErr()
+		}
+		numSocks, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid num socks: %w", err)
+		}
+		if numSocks < 1 {
+			return fmt.Errorf("num socks can not be zero or negative: %d", numSocks)
+		}
+		config.NumSocks = numSocks
+	}
+	return nil
+}

--- a/plugin/reuseport/reuseport_test.go
+++ b/plugin/reuseport/reuseport_test.go
@@ -1,0 +1,49 @@
+package reuseport
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coredns/caddy"
+)
+
+func TestReuseport(t *testing.T) {
+	tests := []struct {
+		input              string
+		shouldErr          bool
+		expectedRoot       string // expected root, set to the controller. Empty for negative cases.
+		expectedErrContent string // substring from the expected error. Empty for positive cases.
+	}{
+		// positive
+		{`reuseport 2`, false, "", ""},
+		{` reuseport 1`, false, "", ""},
+		{`reuseport text`, true, "", "invalid num socks"},
+		{`reuseport 0`, true, "", "num socks can not be zero or negative"},
+		{`reuseport -1`, true, "", "num socks can not be zero or negative"},
+		{`reuseport 2 2`, true, "", "Wrong argument count or unexpected line ending after '2'"},
+		{`reuseport`, true, "", "Wrong argument count or unexpected line ending after 'reuseport'"},
+		{`reuseport 2 {
+			block
+		}`, true, "", "Unexpected token '{', expecting argument"},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		err := setup(c)
+		//cfg := dnsserver.GetConfig(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: Expected error but found %s for input %s", i, err, test.input)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: Expected no error but found one for input %s. Error was: %v", i, test.input, err)
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErrContent) {
+				t.Errorf("Test %d: Expected error to contain: %v, found error: %v, input: %s", i, test.expectedErrContent, err, test.input)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Added the ability to run multiple servers on the same port using the **reuseport** plugin. This increases the throughput of CoreDNS in environments with a large number of CPU cores.

Syntax:
```
reuseport [NUM_SOCKS]
```

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/5595

### 3. Which documentation changes (if any) need to be made?

I added a readme for the plugin. After merging to CoreDNS repo, need to re-generate https://coredns.io/plugins/ using https://github.com/coredns/coredns.io

### 4. Does this introduce a backward incompatible change or deprecation?

Changes are backward compatible